### PR TITLE
Fix checkbox unchecking

### DIFF
--- a/user_flow_prototype/03.refine/new-user-7-refine.html
+++ b/user_flow_prototype/03.refine/new-user-7-refine.html
@@ -112,7 +112,7 @@
          <p><strong>You can subscribe to everything published by Department for Work and Pensions or specific policy areas</strong></p>
          <fieldset>
            <div class="multiple-choice" data-target="immediately">
-             <input id="example-1" type="checkbox" name="checkbox-topic" checked>
+             <input id="example-1" type="checkbox" name="checkbox-topic">
              <label for="example-1">Everything in Department for Work and Pensions</label>
            </div>
          </fieldset>
@@ -120,159 +120,159 @@
          <fieldset class="panel" style="margin-left: 1.1em; padding-left: 1.5em;">
 
            <div class="multiple-choice" data-target="daily">
-             <input id="example-01" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-01" type="checkbox" name="checkbox-child-topic">
              <label for="example-01">Arts and culture</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-02" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-02" type="checkbox" name="checkbox-child-topic">
              <label for="example-02">Borders and immigration</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-03" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-03" type="checkbox" name="checkbox-child-topic">
              <label for="example-03">Business and enterprise</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-04" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-04" type="checkbox" name="checkbox-child-topic">
              <label for="example-04">Children and young people</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-05" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-05" type="checkbox" name="checkbox-child-topic">
              <label for="example-05">Climate change</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-06" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-06" type="checkbox" name="checkbox-child-topic">
              <label for="example-06">Community and society</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-07" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-07" type="checkbox" name="checkbox-child-topic">
              <label for="example-07">Consumer rights and issues</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-08" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-08" type="checkbox" name="checkbox-child-topic">
              <label for="example-08">Defence and armed forces</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-09" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-09" type="checkbox" name="checkbox-child-topic">
              <label for="example-09">Employment</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-10" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-10" type="checkbox" name="checkbox-child-topic">
              <label for="example-10">Energy</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-11" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-11" type="checkbox" name="checkbox-child-topic">
              <label for="example-11">Environment</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-12" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-12" type="checkbox" name="checkbox-child-topic">
              <label for="example-12">Equality, rights and citizenship</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-13" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-13" type="checkbox" name="checkbox-child-topic">
              <label for="example-13">Europe</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-14" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-14" type="checkbox" name="checkbox-child-topic">
              <label for="example-14">Financial services</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-15" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-15" type="checkbox" name="checkbox-child-topic">
              <label for="example-15">Foreign affairs</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-16" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-16" type="checkbox" name="checkbox-child-topic">
              <label for="example-16">Further education and skills</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-17" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-17" type="checkbox" name="checkbox-child-topic">
              <label for="example-17">Government efficiency, transparency and accountability</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-18" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-18" type="checkbox" name="checkbox-child-topic">
              <label for="example-18">Government spending</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-19" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-19" type="checkbox" name="checkbox-child-topic">
              <label for="example-19">Housing</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-20" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-20" type="checkbox" name="checkbox-child-topic">
              <label for="example-20">International aid and development</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-21" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-21" type="checkbox" name="checkbox-child-topic">
              <label for="example-21">Law and the justice system</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-22" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-22" type="checkbox" name="checkbox-child-topic">
              <label for="example-22">Local government</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-23" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-23" type="checkbox" name="checkbox-child-topic">
              <label for="example-23">Media and communications</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-24" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-24" type="checkbox" name="checkbox-child-topic">
              <label for="example-24">National Health Service</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-25" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-25" type="checkbox" name="checkbox-child-topic">
              <label for="example-25">Pensions and ageing society</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-26" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-26" type="checkbox" name="checkbox-child-topic">
              <label for="example-26">Planning and building</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-27" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-27" type="checkbox" name="checkbox-child-topic">
              <label for="example-27">Public health</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-28" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-28" type="checkbox" name="checkbox-child-topic">
              <label for="example-28">Public safety and emergencies</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-29" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-29" type="checkbox" name="checkbox-child-topic">
              <label for="example-29">Regulation reform</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-30" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-30" type="checkbox" name="checkbox-child-topic">
              <label for="example-30">Schools</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-31" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-31" type="checkbox" name="checkbox-child-topic">
              <label for="example-31">Scotland</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-32" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-32" type="checkbox" name="checkbox-child-topic">
              <label for="example-32">Social care</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-33" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-33" type="checkbox" name="checkbox-child-topic">
              <label for="example-33">Sports and leisure</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-34" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-34" type="checkbox" name="checkbox-child-topic">
              <label for="example-34">Tax and revenue</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-35" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-35" type="checkbox" name="checkbox-child-topic">
              <label for="example-35">Trade and investment</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-36" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-36" type="checkbox" name="checkbox-child-topic">
              <label for="example-36">Transport</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-37" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-37" type="checkbox" name="checkbox-child-topic">
              <label for="example-37">UK economy</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-38" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-38" type="checkbox" name="checkbox-child-topic">
              <label for="example-38">Wales</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-39" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-39" type="checkbox" name="checkbox-child-topic">
              <label for="example-39">Welfare</label>
            </div>
          </fieldset>

--- a/user_flow_prototype/03.refine/new-user-7.html
+++ b/user_flow_prototype/03.refine/new-user-7.html
@@ -112,7 +112,7 @@
          <p><strong>You can subscribe to everything published by Department for Work and Pensions or specific policy areas</strong></p>
          <fieldset>
            <div class="multiple-choice" data-target="immediately">
-             <input id="example-1" type="checkbox" name="checkbox-topic" checked>
+             <input id="example-1" type="checkbox" name="checkbox-topic">
              <label for="example-1">Everything in Department for Work and Pensions</label>
            </div>
          </fieldset>
@@ -120,159 +120,159 @@
          <fieldset class="panel" style="margin-left: 1.1em; padding-left: 1.5em;">
 
            <div class="multiple-choice" data-target="daily">
-             <input id="example-01" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-01" type="checkbox" name="checkbox-child-topic">
              <label for="example-01">Arts and culture</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-02" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-02" type="checkbox" name="checkbox-child-topic">
              <label for="example-02">Borders and immigration</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-03" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-03" type="checkbox" name="checkbox-child-topic">
              <label for="example-03">Business and enterprise</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-04" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-04" type="checkbox" name="checkbox-child-topic">
              <label for="example-04">Children and young people</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-05" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-05" type="checkbox" name="checkbox-child-topic">
              <label for="example-05">Climate change</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-06" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-06" type="checkbox" name="checkbox-child-topic">
              <label for="example-06">Community and society</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-07" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-07" type="checkbox" name="checkbox-child-topic">
              <label for="example-07">Consumer rights and issues</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-08" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-08" type="checkbox" name="checkbox-child-topic">
              <label for="example-08">Defence and armed forces</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-09" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-09" type="checkbox" name="checkbox-child-topic">
              <label for="example-09">Employment</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-10" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-10" type="checkbox" name="checkbox-child-topic">
              <label for="example-10">Energy</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-11" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-11" type="checkbox" name="checkbox-child-topic">
              <label for="example-11">Environment</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-12" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-12" type="checkbox" name="checkbox-child-topic">
              <label for="example-12">Equality, rights and citizenship</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-13" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-13" type="checkbox" name="checkbox-child-topic">
              <label for="example-13">Europe</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-14" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-14" type="checkbox" name="checkbox-child-topic">
              <label for="example-14">Financial services</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-15" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-15" type="checkbox" name="checkbox-child-topic">
              <label for="example-15">Foreign affairs</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-16" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-16" type="checkbox" name="checkbox-child-topic">
              <label for="example-16">Further education and skills</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-17" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-17" type="checkbox" name="checkbox-child-topic">
              <label for="example-17">Government efficiency, transparency and accountability</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-18" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-18" type="checkbox" name="checkbox-child-topic">
              <label for="example-18">Government spending</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-19" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-19" type="checkbox" name="checkbox-child-topic">
              <label for="example-19">Housing</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-20" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-20" type="checkbox" name="checkbox-child-topic">
              <label for="example-20">International aid and development</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-21" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-21" type="checkbox" name="checkbox-child-topic">
              <label for="example-21">Law and the justice system</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-22" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-22" type="checkbox" name="checkbox-child-topic">
              <label for="example-22">Local government</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-23" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-23" type="checkbox" name="checkbox-child-topic">
              <label for="example-23">Media and communications</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-24" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-24" type="checkbox" name="checkbox-child-topic">
              <label for="example-24">National Health Service</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-25" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-25" type="checkbox" name="checkbox-child-topic">
              <label for="example-25">Pensions and ageing society</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-26" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-26" type="checkbox" name="checkbox-child-topic">
              <label for="example-26">Planning and building</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-27" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-27" type="checkbox" name="checkbox-child-topic">
              <label for="example-27">Public health</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-28" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-28" type="checkbox" name="checkbox-child-topic">
              <label for="example-28">Public safety and emergencies</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-29" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-29" type="checkbox" name="checkbox-child-topic">
              <label for="example-29">Regulation reform</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-30" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-30" type="checkbox" name="checkbox-child-topic">
              <label for="example-30">Schools</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-31" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-31" type="checkbox" name="checkbox-child-topic">
              <label for="example-31">Scotland</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-32" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-32" type="checkbox" name="checkbox-child-topic">
              <label for="example-32">Social care</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-33" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-33" type="checkbox" name="checkbox-child-topic">
              <label for="example-33">Sports and leisure</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-34" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-34" type="checkbox" name="checkbox-child-topic">
              <label for="example-34">Tax and revenue</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-35" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-35" type="checkbox" name="checkbox-child-topic">
              <label for="example-35">Trade and investment</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-36" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-36" type="checkbox" name="checkbox-child-topic">
              <label for="example-36">Transport</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-37" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-37" type="checkbox" name="checkbox-child-topic">
              <label for="example-37">UK economy</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-38" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-38" type="checkbox" name="checkbox-child-topic">
              <label for="example-38">Wales</label>
            </div>
            <div class="multiple-choice" data-target="daily">
-             <input id="example-39" type="checkbox" name="checkbox-child-topic" checked>
+             <input id="example-39" type="checkbox" name="checkbox-child-topic">
              <label for="example-39">Welfare</label>
            </div>
          </fieldset>

--- a/user_flow_prototype/03.refine/new-user-8-refine.html
+++ b/user_flow_prototype/03.refine/new-user-8-refine.html
@@ -208,7 +208,7 @@
                   }
                });
 
-               $('input[name="checkbox-child-topic"]').click(function() {
+               $('input[class="checkbox-child-policy-area"]').click(function() {
                  if ($(this).prop("checked")){
                      null;
                   } else {

--- a/user_flow_prototype/03.refine/new-user-8.html
+++ b/user_flow_prototype/03.refine/new-user-8.html
@@ -204,7 +204,7 @@
                   }
                });
 
-               $('input[name="checkbox-child-topic"]').click(function() {
+               $('input[class="checkbox-child-policy-area"]').click(function() {
                  if ($(this).prop("checked")){
                      null;
                   } else {


### PR DESCRIPTION
New DWP pages should have the checkboxes unchecked by default.

On the DfE refine pages, we want to ensure that when all items in the hierarchy are checked and a child item is unchecked, the parent checkbox is also unchecked to reflect the fact that we are no longer selecting everything under the hierarchy.